### PR TITLE
Added host permission in Vite config

### DIFF
--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -4,4 +4,10 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    host: '0.0.0.0', 
+  },
+  preview: {
+    allowedHosts: ['booktopia-app-z.onrender.com'], 
+  },
 })


### PR DESCRIPTION
Added host permission in Vite config due to this error : 

Blocked request. This host ("booktopia-app-z.onrender.com") is not allowed.
To allow this host, add "booktopia-app-z.onrender.com" to preview.allowedHosts in vite.config.js.